### PR TITLE
feat: add support for multiple images in artwork descriptions

### DIFF
--- a/src/app/artworks/[id]/page.tsx
+++ b/src/app/artworks/[id]/page.tsx
@@ -49,8 +49,19 @@ export default function ArtworkPage() {
       <Artwork artworkInfo={artwork} />
 
       {/* Descrição Ajustada */}
-      <div className="w-full max-w-3xl p-6 md:p-8 lg:p-10 ">
-        <p className="text-lg">{artwork.description}</p>
+      <div className="w-full max-w-3xl p-6 md:p-8 lg:p-10 space-y-6">
+        {artwork.description.map((section, index) => (
+          <div key={index} className="mb-6">
+            <p className="text-lg">{section.text}</p>
+            {section.image && (
+              <img
+                src={section.image}
+                alt={`Imagem de ${artwork.title}`}
+                className="w-full mt-4 rounded-lg shadow-md"
+              />
+            )}
+          </div>
+        ))}
       </div>
 
       {/* Botão de Voltar */}

--- a/src/app/artworks/page.tsx
+++ b/src/app/artworks/page.tsx
@@ -18,7 +18,7 @@ function ArtworksPage() {
               {/* Imagem */}
               <div className="w-full h-64 flex items-center justify-center ">
                 <Image
-                  src={artwork.image}
+                  src={artwork.coverImage}
                   width={300}
                   height={400} // Mantemos um valor maior para suportar obras verticais
                   alt={artwork.title}

--- a/src/app/components/Artwork/Artwork.tsx
+++ b/src/app/components/Artwork/Artwork.tsx
@@ -11,7 +11,7 @@ function Artwork({ artworkInfo }: ArtworkProps) {
       {/* Imagem da Obra */}
       <div className="w-full md:w-1/2 flex justify-center">
         <Image
-          src={artworkInfo.image}
+          src={artworkInfo.coverImage}
           width={1000}
           height={1000}
           alt={`Obra: ${artworkInfo.title}`}

--- a/src/app/data/artworks.ts
+++ b/src/app/data/artworks.ts
@@ -10,7 +10,7 @@ export const artworks: Artwork[] = [
     style: 'Modernismo, Cubismo',
     technique: 'Óleo sobre tela',
     location: 'Café Martinho da Arcada, Lisboa',
-    image:
+    coverImage:
       'https://res.cloudinary.com/dtglidvcw/image/upload/v1739629102/everythingAboutArt/artworks/fernando-pessoa-almada-negreiros.jpg',
 
     curiosities: [
@@ -28,28 +28,29 @@ export const artworks: Artwork[] = [
 
     quote: 'Um homem é do tamanho do seu sonho. – Fernando Pessoa',
 
-    description: `
-      Esta obra é da autoria do pintor português Almada Negreiros. 
-      Foi pintada numa das arcadas da Praça do Comércio, no café Martinho da Arcada, em Lisboa.
-
-      Era Verão de 1915 e, na obra, o poeta Fernando Pessoa procurava inspiração, inclinado sobre a mesa.
-      A tensão quebra-se se olharem para o tornozelo que está torcido e numa posição frágil. 
-      O chão e o fundo do quadro estão cheios de formas. 
-
-      O pintor desta obra participou, junto com o poeta, na revista Orfeu que aparece no quadro. 
-      Os losangos fazem lembrar os fatos de Arlequim, que o pintor gostava muito. 
-      Reparem no açucareiro: está pintado com uma amolgadela, 
-      pois é um objeto que as pessoas deixam sempre cair frequentemente.
-
-      Quando este quadro foi vendido pela primeira vez ao restaurante Irmãos Unidos, 
-      custou 30 contos, que hoje é o equivalente a 150 euros. 
-      Mas passados alguns anos, o restaurante fechou e houve muita gente a querer comprá-lo. 
-      Alguém pagou 6700 euros, ou seja, quarenta e cinco vezes mais. 
-      Nunca uma obra de um pintor português vivo tinha valido tanto.
-
-      E aqui fica uma frase típica de Pessoa: 
-      "Um homem é do tamanho do seu sonho."
-    `,
+    description: [
+      {
+        text: 'Esta obra é da autoria do pintor português Almada Negreiros. Foi pintada numa das arcadas da Praça do Comércio, no café Martinho da Arcada, em Lisboa.',
+      },
+      {
+        text: 'Era Verão de 1915 e, na obra, o poeta Fernando Pessoa procurava inspiração, inclinado sobre a mesa. A tensão quebra-se se olharem para o tornozelo que está torcido e numa posição frágil.',
+      },
+      {
+        text: 'O chão e o fundo do quadro estão cheios de formas. O pintor desta obra participou, junto com o poeta, na revista Orfeu que aparece no quadro. Os losangos fazem lembrar os fatos de Arlequim, que o pintor gostava muito.',
+      },
+      {
+        text: 'Reparem no açucareiro: está pintado com uma amolgadela, pois é um objeto que as pessoas deixam sempre cair frequentemente.',
+      },
+      {
+        text: 'Quando este quadro foi vendido pela primeira vez ao restaurante Irmãos Unidos, custou 30 contos, que hoje é o equivalente a 150 euros. Mas passados alguns anos, o restaurante fechou e houve muita gente a querer comprá-lo.',
+      },
+      {
+        text: 'Alguém pagou 6700 euros, ou seja, quarenta e cinco vezes mais. Nunca uma obra de um pintor português vivo tinha valido tanto.',
+      },
+      {
+        text: 'E aqui fica uma frase típica de Pessoa: "Um homem é do tamanho do seu sonho."',
+      },
+    ],
   },
   {
     id: 'composicao-vermelho-azul-amarelo',
@@ -60,9 +61,8 @@ export const artworks: Artwork[] = [
     style: 'Neoplasticismo, Modernismo',
     technique: 'Óleo sobre tela',
     location: 'Museu Gemeentemuseum, Haia, Holanda',
-    image:
+    coverImage:
       'https://res.cloudinary.com/dtglidvcw/image/upload/v1740216146/everythingAboutArt/artworks/Mondrian.jpg',
-
     curiosities: [
       'A pintura parece invertida, mas está corretamente posicionada.',
       'Mondrian foi o criador do movimento artístico Neoplasticismo.',
@@ -70,30 +70,27 @@ export const artworks: Artwork[] = [
       'As cores primárias usadas (vermelho, azul e amarelo) são a base de todas as outras cores.',
       'A composição reflete o ritmo do jazz, que Mondrian apreciava após viver em Nova Iorque.',
     ],
-
     quote: 'O mínimo é o máximo. – Piet Mondrian',
-
-    description: `
-      Esta obra é da autoria do pintor holandês Piet Mondrian.  
-      Podem pensar que está invertido, mas, na verdade, é assim mesmo.
-
-      Mondrian era um pintor modernista e criador do movimento artístico conhecido como Neoplasticismo.  
-      No início, pintava o que via, mas foi retirando elementos considerados superficiais até chegar à geometria pura.  
-
-      O preto presente no quadro representa a ausência de luz, enquanto o branco simboliza a mistura de todas as cores.  
-      Mondrian utilizava cores primárias (vermelho, amarelo e azul) porque são a base de todas as outras cores.  
-      O preto e o branco servem para contornar e equilibrar os blocos de cor.
-
-      Quando Mondrian esteve em Nova Iorque, ficou fascinado pela energia do jazz e quis transmitir essas emoções  
-      por meio das cores vibrantes e da composição geométrica da obra.
-
-      Agora passemos à forma como as cores se equilibram.  
-      O quadrado vermelho é a forma maior, e a forma azul cabe nove vezes dentro dele.  
-      Os dois retângulos verticais cabem dentro do retângulo horizontal.  
-      No canto inferior direito, há dois retângulos do mesmo tamanho: um branco e outro amarelo.
-
-      Para Piet Mondrian, o mínimo é o máximo.
-    `,
+    description: [
+      {
+        text: 'Esta obra é da autoria do pintor holandês Piet Mondrian. Podem pensar que está invertido, mas, na verdade, é assim mesmo.',
+      },
+      {
+        text: 'Mondrian era um pintor modernista e criador do movimento artístico conhecido como Neoplasticismo. No início, pintava o que via, mas foi retirando elementos considerados superficiais até chegar à geometria pura.',
+      },
+      {
+        text: 'O preto presente no quadro representa a ausência de luz, enquanto o branco simboliza a mistura de todas as cores. Mondrian utilizava cores primárias (vermelho, amarelo e azul) porque são a base de todas as outras cores. O preto e o branco servem para contornar e equilibrar os blocos de cor.',
+      },
+      {
+        text: 'Quando Mondrian esteve em Nova Iorque, ficou fascinado pela energia do jazz e quis transmitir essas emoções por meio das cores vibrantes e da composição geométrica da obra.',
+      },
+      {
+        text: 'Agora passemos à forma como as cores se equilibram. O quadrado vermelho é a forma maior, e a forma azul cabe nove vezes dentro dele. Os dois retângulos verticais cabem dentro do retângulo horizontal. No canto inferior direito, há dois retângulos do mesmo tamanho: um branco e outro amarelo.',
+      },
+      {
+        text: 'Para Piet Mondrian, o mínimo é o máximo.',
+      },
+    ],
     priceHistory: {
       firstSale: 'Desconhecido',
       resale: 'Desconhecido',
@@ -109,8 +106,14 @@ export const artworks: Artwork[] = [
     style: 'Caricatura, Sátira Política',
     technique: 'Ilustração, Cerâmica',
     location: 'Museu Bordalo Pinheiro, Lisboa',
-    image:
-      'https://res.cloudinary.com/dtglidvcw/image/upload/v1740217858/everythingAboutArt/artworks/zepovinho.jpg',
+    coverImage:
+      'https://res.cloudinary.com/dtglidvcw/image/upload/v1740218784/everythingAboutArt/artworks/zepovinhoalbumdasglorias.png',
+
+    images: [
+      'https://res.cloudinary.com/dtglidvcw/image/upload/v1740223972/everythingAboutArt/artworks/lanternamagica2.png',
+      'https://res.cloudinary.com/dtglidvcw/image/upload/v1740223126/everythingAboutArt/artworks/thesituation.jpg',
+      'https://res.cloudinary.com/dtglidvcw/image/upload/v1740223270/everythingAboutArt/artworks/zepovinhoestatua.jpg',
+    ],
 
     curiosities: [
       'O Zé Povinho foi criado como símbolo do povo português.',
@@ -122,31 +125,35 @@ export const artworks: Artwork[] = [
 
     quote: 'O povo é que manda no país, e não o rei. – Rafael Bordalo Pinheiro',
 
-    description: `
-      O Zé Povinho foi inventado pelo artista português Rafael Bordalo Pinheiro em 1875 para representar o povo português.
-      Ele é conhecido pelo seu famoso gesto, o “Toma!”, que simboliza sua revolta contra os políticos, a sociedade e os impostos abusivos.
-      Sendo analfabeto, encontrou no gesto uma forma de expressar sua insatisfação.
-
-      Uma das suas primeiras aparições foi no Álbum das Glórias, onde era representado como um homem ingênuo e resignado,
-      aceitando as injustiças impostas pelos governantes. A albarda ao seu lado simboliza os encargos, impostos e abusos políticos,
-      colocando o Zé Povinho na posição de um burro sobrecarregado. A legenda "O Soberano!" ironiza a ideia de que o povo teria poder, 
-      quando, na realidade, sofria com as decisões dos governantes.
-
-      Sua estreia na imprensa aconteceu em 12 de junho de 1875 na revista "A Lanterna Mágica". Nesta caricatura, o ministro das finanças, 
-      Serpa Pimentel, pede três tostões ao Zé Povinho para Santo António de Lisboa. Porém, a verdadeira sátira está no rosto da figura religiosa,
-      que na verdade representa Fontes Pereira de Melo, chefe do governo, e o bebê ao colo simboliza o rei D. Luís I. Um guarda com um chicote
-      aparece ao fundo, pronto para punir Zé Povinho caso ele se recuse a pagar. Essa imagem reflete a exploração do povo pelo governo.
-
-      O Zé Povinho ganhou notoriedade internacional, sendo reconhecido além das fronteiras de Portugal. Em uma caricatura chamada "A Situação",
-      ele aparece representando o povo português enquanto carrega um fardo nas costas. Ao seu lado, John Bull, símbolo da Inglaterra,
-      destaca a influência do Reino Unido sobre o país. A bandeira inglesa se impõe sobre a portuguesa, ilustrando o domínio estrangeiro sobre a nação.
-      Fontes Pereira de Melo e outros políticos aparecem montados em cavalos, enquanto o Zé Povinho é retratado como um burro,
-      carregando o peso das mudanças políticas constantes. 
-
-      Além de suas caricaturas, Rafael Bordalo Pinheiro também imortalizou o Zé Povinho na cerâmica, criando estátuas que reforçavam
-      a crítica social. Ele foi um artista multifacetado, atuando como ilustrador, ceramista e satirista, deixando um legado que 
-      continua a ser estudado e apreciado até os dias de hoje.
-    `,
+    description: [
+      {
+        text: 'O Zé Povinho foi inventado pelo artista português Rafael Bordalo Pinheiro em 1875 para representar o povo português.',
+      },
+      {
+        text: 'Ele é conhecido pelo seu famoso gesto, o “Toma!”, que simboliza sua revolta contra os políticos, a sociedade e os impostos abusivos.',
+      },
+      {
+        text: 'Uma das suas primeiras aparições foi no Álbum das Glórias, onde era representado como um homem ingênuo e resignado, aceitando as injustiças impostas pelos governantes.',
+      },
+      {
+        text: 'A albarda ao seu lado simboliza os encargos, impostos e abusos políticos, colocando o Zé Povinho na posição de um burro sobrecarregado.',
+        image:
+          'https://res.cloudinary.com/dtglidvcw/image/upload/v1740223972/everythingAboutArt/artworks/lanternamagica2.png',
+      },
+      {
+        text: 'Sua estreia na imprensa aconteceu em 12 de junho de 1875 na revista "A Lanterna Mágica".',
+      },
+      {
+        text: 'O Zé Povinho ganhou notoriedade internacional, sendo reconhecido além das fronteiras de Portugal. Em uma caricatura chamada "A Situação", ele aparece representando o povo português enquanto carrega um fardo nas costas.',
+        image:
+          'https://res.cloudinary.com/dtglidvcw/image/upload/v1740223126/everythingAboutArt/artworks/thesituation.jpg',
+      },
+      {
+        text: 'Além de suas caricaturas, Rafael Bordalo Pinheiro também imortalizou o Zé Povinho na cerâmica, criando estátuas que reforçavam a crítica social.',
+        image:
+          'https://res.cloudinary.com/dtglidvcw/image/upload/v1740223270/everythingAboutArt/artworks/zepovinhoestatua.jpg',
+      },
+    ],
 
     priceHistory: {
       firstSale: 'Desconhecido',

--- a/src/app/types/artworks.ts
+++ b/src/app/types/artworks.ts
@@ -7,12 +7,13 @@ export interface Artwork {
   style: string;
   technique: string;
   location: string;
-  image: string;
+  coverImage: string;
+  images?: string[];
   curiosities: string[];
   priceHistory: {
     firstSale: string;
     resale: string;
   };
   quote: string;
-  description: string;
+  description: { text: string; image?: string }[]; // Alterado para array de objetos
 }


### PR DESCRIPTION
- Updated artwork data structure to include an array of descriptions, allowing insertion of images between paragraphs.
- Re-added detailed information for Piet Mondrian's "Composição com Vermelho, Azul e Amarelo".
- Improved layout for displaying descriptions with interleaved images.