### PR TITLE
feat: implementar paginacao na API e na pagina de artworks

### DIFF
--- a/src/app/api/artworks/route.ts
+++ b/src/app/api/artworks/route.ts
@@ -11,10 +11,21 @@ const ensureJSON = <T>(data: Prisma.JsonValue | null): T | null => {
   return null;
 };
 
-// GET - Retorna todas as obras de arte
-export async function GET() {
+// GET - Retorna todas as obras de arte com paginação
+export async function GET(req: Request) {
   try {
-    const artworks = await prisma.artwork.findMany();
+    const { searchParams } = new URL(req.url);
+    const page = parseInt(searchParams.get('page') || '1', 10);
+    const limit = parseInt(searchParams.get('limit') || '9', 10);
+    const offset = (page - 1) * limit;
+
+    // Contagem total de obras para calcular páginas
+    const totalArtworks = await prisma.artwork.count();
+
+    const artworks = await prisma.artwork.findMany({
+      skip: offset,
+      take: limit,
+    });
 
     const formattedArtworks = artworks.map((artwork) => ({
       id: artwork.id,
@@ -35,7 +46,17 @@ export async function GET() {
       createdAt: artwork.createdat,
     }));
 
-    return NextResponse.json(formattedArtworks, { status: 200 });
+    return NextResponse.json(
+      {
+        artworks: formattedArtworks,
+        pagination: {
+          currentPage: page,
+          totalPages: Math.ceil(totalArtworks / limit),
+          totalArtworks,
+        },
+      },
+      { status: 200 }
+    );
   } catch (error) {
     console.error('Erro ao buscar as obras de arte:', error);
     return NextResponse.json(

--- a/src/app/artworks/page.tsx
+++ b/src/app/artworks/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import Pagination from '../components/Pagination';
 
 interface Artwork {
   id: string;
@@ -21,15 +22,25 @@ function ArtworksPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // 🔹 Estado para paginação
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const artworksPerPage = 9; // Defina o número de obras por página
+
   useEffect(() => {
     async function fetchArtworks() {
       try {
-        const response = await fetch('/api/artworks');
+        setLoading(true);
+        const response = await fetch(
+          `/api/artworks?page=${currentPage}&limit=${artworksPerPage}`
+        );
         if (!response.ok) {
           throw new Error('Erro ao buscar as obras de arte');
         }
         const data = await response.json();
-        setArtworks(data);
+
+        setArtworks(data.artworks || []);
+        setTotalPages(data.pagination.totalPages || 1);
       } catch (err) {
         setError('Falha ao carregar as obras de arte.');
         console.error('Erro ao buscar as obras:', err);
@@ -39,7 +50,13 @@ function ArtworksPage() {
     }
 
     fetchArtworks();
-  }, []);
+  }, [currentPage]); // 🔹 Atualiza sempre que a página muda
+
+  const handlePageChange = (page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page);
+    }
+  };
 
   if (loading) {
     return (
@@ -62,35 +79,48 @@ function ArtworksPage() {
       <h1 className="text-3xl font-bold mb-8">Obras de Arte</h1>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 w-full max-w-5xl">
-        {artworks.map((artwork) => (
-          <Link
-            key={artwork.id}
-            href={`/artworks/${artwork.id}`}
-            className="group"
-          >
-            <div className="shadow-md overflow-hidden transition-transform transform hover:scale-105 rounded-lg">
-              {/* Imagem */}
-              <div className="w-full h-64 flex items-center justify-center">
-                <Image
-                  src={artwork.image}
-                  width={300}
-                  height={400} // Mantemos um valor maior para suportar obras verticais
-                  alt={artwork.title}
-                  className="w-auto h-full max-h-64 object-contain"
-                />
-              </div>
+        {artworks.length > 0 ? (
+          artworks.map((artwork) => (
+            <Link
+              key={artwork.id}
+              href={`/artworks/${artwork.id}`}
+              className="group"
+            >
+              <div className="shadow-md overflow-hidden transition-transform transform hover:scale-105 rounded-lg">
+                {/* Imagem */}
+                <div className="w-full h-64 flex items-center justify-center">
+                  <Image
+                    src={artwork.image}
+                    width={300}
+                    height={400}
+                    alt={artwork.title}
+                    className="w-auto h-full max-h-64 object-contain"
+                  />
+                </div>
 
-              {/* Informações */}
-              <div className="p-4 text-center">
-                <h2 className="text-lg font-bold text-yellow-500">
-                  {artwork.title}
-                </h2>
-                <p className="text-sm">{artwork.artist}</p>
+                {/* Informações */}
+                <div className="p-4 text-center">
+                  <h2 className="text-lg font-bold text-yellow-500">
+                    {artwork.title}
+                  </h2>
+                  <p className="text-sm">{artwork.artist}</p>
+                </div>
               </div>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          ))
+        ) : (
+          <p className="text-lg font-bold text-gray-500">
+            Nenhuma obra encontrada.
+          </p>
+        )}
       </div>
+
+      {/* 🔹 Adicionando o componente de paginação */}
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={handlePageChange}
+      />
     </div>
   );
 }

--- a/src/app/artworks/page.tsx
+++ b/src/app/artworks/page.tsx
@@ -25,7 +25,7 @@ function ArtworksPage() {
   // 🔹 Estado para paginação
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
-  const artworksPerPage = 9; // Defina o número de obras por página
+  const artworksPerPage = 6; // Defina o número de obras por página
 
   useEffect(() => {
     async function fetchArtworks() {

--- a/src/app/components/Pagination/index.tsx
+++ b/src/app/components/Pagination/index.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+const Pagination: React.FC<PaginationProps> = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}) => {
+  // Gerar os números de páginas a serem exibidos
+  const getPages = () => {
+    const pages = [];
+    const maxPagesToShow = 5; // Número máximo de páginas visíveis
+
+    let startPage = Math.max(1, currentPage - Math.floor(maxPagesToShow / 2));
+    const endPage = Math.min(totalPages, startPage + maxPagesToShow - 1);
+
+    if (endPage - startPage + 1 < maxPagesToShow) {
+      startPage = Math.max(1, endPage - maxPagesToShow + 1);
+    }
+
+    for (let i = startPage; i <= endPage; i++) {
+      pages.push(i);
+    }
+
+    return pages;
+  };
+
+  return (
+    <div className="flex items-center justify-center gap-2 mt-8">
+      {/* Botão Anterior */}
+      {currentPage > 1 && (
+        <button
+          onClick={() => onPageChange(currentPage - 1)}
+          className="px-3 py-2 text-[var(--foreground)] bg-[var(--background)] hover:bg-[var(--foreground)] hover:text-[var(--background)] transition"
+        >
+          &lt;
+        </button>
+      )}
+
+      {/* Números das páginas */}
+      {getPages().map((page) => (
+        <button
+          key={page}
+          onClick={() => onPageChange(page)}
+          className={`px-4 py-2 rounded border border-[var(--foreground)] transition ${
+            page === currentPage
+              ? 'bg-[var(--foreground)] text-[var(--background)] font-bold'
+              : 'bg-[var(--background)] text-[var(--foreground)] hover:bg-[var(--foreground)] hover:text-[var(--background)]'
+          }`}
+        >
+          {page}
+        </button>
+      ))}
+
+      {/* Botão Próxima */}
+      {currentPage < totalPages && (
+        <button
+          onClick={() => onPageChange(currentPage + 1)}
+          className="px-3 py-2 text-[var(--foreground)] bg-[var(--background)] hover:bg-[var(--foreground)] hover:text-[var(--background)] transition"
+        >
+          &gt;
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default Pagination;


### PR DESCRIPTION
- Adicionada paginacao na API `/api/artworks` com suporte a `page` e `limit`.
- Retorno da API agora inclui metadados de paginacao (`totalPages`, `currentPage` e `totalArtworks`).
- Atualizado `ArtworksPage.tsx` para suportar paginacao dinamica.
- Criado componente `Pagination.tsx` para exibir numeros de paginas clicaveis.
- Ajustado estilo da paginacao para seguir o tema global (modo claro/escuro).
- Melhorada experiencia do usuario ao navegar entre paginas de artworks.